### PR TITLE
Fix negative equipment transfer

### DIFF
--- a/events/United_States_of_America.txt
+++ b/events/United_States_of_America.txt
@@ -3290,7 +3290,7 @@ country_event = { # Red Executive Agreement
 				}
 			add_equipment_to_stockpile = {
 			type = infantry_equipment
-			amount = -600
+			amount = 600
 			producer = USA
 				}
 			}


### PR DESCRIPTION
This option should remove equipment from the US and give it to France, but instead it subtracts equipment from both. Probably a copy/paste mistake.