### PR TITLE
Update path in descriptor.mod for non-Windows compatibility

### DIFF
--- a/descriptor.mod
+++ b/descriptor.mod
@@ -69,5 +69,5 @@ tags={
 	"National Focuses"
 }
 supported_version="1.10.*"
-path="C:/Users/User/Documents/Paradox Interactive/Hearts of Iron IV/mod/kx"
+path="mod/kx"
 remote_file_id="2206134307"


### PR DESCRIPTION
This should also make the descriptor work out of the box for Windows users as well, as they no longer have to replace the User placeholders with their username.